### PR TITLE
Adding storage_resolution configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ $ export GOOS=darwin;make
               config:
                 region: "us-east-1"
                 namespace: "snap"
+                storage_resolution: 60
 
 ```
 Create task:

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -65,6 +65,7 @@ func TestCloudWatchPlugin(t *testing.T) {
 			testConfig := make(map[string]ctypes.ConfigValue)
 			testConfig["namespace"] = ctypes.ConfigValueStr{Value: "snap"}
 			testConfig["region"] = ctypes.ConfigValueStr{Value: "us-east-1"}
+			testConfig["storage_resolution"] = ctypes.ConfigValueInt{Value: 60}
 			cfg, errs := configPolicy.Get([]string{""}).Process(testConfig)
 			Convey("So config policy should process testConfig and return a config", func() {
 				So(cfg, ShouldNotBeNil)


### PR DESCRIPTION
Snap has the capability to collect metrics at sub-60 second intervals, which can be stored in CloudWatch at the same granularity via specifying the StorageResolution option on a MetricDatum struct.

This PR adds a configuration option, "storage_resolution", which allows this value to be configured by collection task. It is not required and defaults to the AWS standard 60 second resolution.

Let me know what you think and thanks much for building this plugin!